### PR TITLE
Remove old canvas, clean up watchers on reinitialization, better max value support

### DIFF
--- a/src/directives/justgage.js
+++ b/src/directives/justgage.js
@@ -73,7 +73,12 @@ angular.module('frapontillo.gage.directives', ['frapontillo.gage.controllers'])
           var bindValue = function() {
             watchers.push(scope.$watch('value', function(newValue, oldValue) {
               if (newValue !== oldValue) {
-                justgage.refresh(newValue);
+                justgage.refresh(newValue, scope.max);
+              }
+            }));
+            watchers.push(scope.$watch('max', function(newValue, oldValue) {
+              if (newValue !== oldValue) {
+                justgage.refresh(scope.value, newValue);
               }
             }));
           };
@@ -83,7 +88,7 @@ angular.module('frapontillo.gage.directives', ['frapontillo.gage.controllers'])
            * one of them changes.
            */
           var bindOtherOptions = function() {
-            var otherOptionsNames = justgageCtrl.getOptionsNames('value');
+            var otherOptionsNames = justgageCtrl.getOptionsNames(['value', 'max']);
             // TODO: move to angularjs 1.3 and replace with $watchGroup
             angular.forEach(otherOptionsNames, function (name) {
               watchers.push(scope.$watch(name, function(newValue, oldValue) {


### PR DESCRIPTION
Hi,

I have improved some bits and pieces:
- Max value is now updated through refresh, as justgage permits that https://github.com/toorshia/justgage/blob/b5398633c52c2027607d93f88432ce176ddac9c6/justgage.js#L778-L779
- On reinitialization old canvas object is removed
- Old watchers are cleaned up when new JustGage object is created.

Let me know what you think.

Cheers,
Igor.
