### PR TITLE
Features have been added: bump version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gage",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AngularJS directive for the JustGage (http://justgage.com/) gauge.",
   "main": "./dist/angular-gage.js",
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gage",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Since we have the new options merged, it would be nice to be able to _use_ the new version from our projects. I am bumping the version minor (because: new feature, I assumed semver) in `package.json` and `bower.json`, and I kindly ask to make a `v0.2.0` tag afterwards :) 
